### PR TITLE
feat: expand hero with chart

### DIFF
--- a/app/demo/page.tsx
+++ b/app/demo/page.tsx
@@ -11,8 +11,6 @@ import {
   Users,
   Clock,
   ArrowUpRight,
-  Play,
-  Pause,
   Brain,
   Zap,
   Target,
@@ -32,7 +30,7 @@ import {
 
 export default function Page() {
   const router = useRouter();
-  const [isLive, setIsLive] = useState(true);
+  const [isLive] = useState(true);
   const [timeRange, setTimeRange] = useState("30d");
   const [visitors, setVisitors] = useState(47892);
   const [pageviews, setPageviews] = useState(128456);

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -3,8 +3,30 @@ import { ReactNode } from "react";
 import { motion } from "framer-motion";
 import { Button } from "./ui/button";
 import { ArrowRight, Play, TrendingUp, Zap } from "lucide-react";
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+} from "recharts";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "./ui/chart";
 
 export default function Hero({ cta }: { cta?: ReactNode }) {
+  const values = [1200, 4500, 3800, 5400, 7200, 9600];
+  const chartData = values.map((value, index) => {
+    const date = new Date();
+    date.setMonth(date.getMonth() - (5 - index));
+    return {
+      month: date.toLocaleString("default", { month: "short" }),
+      visitors: value,
+    };
+  });
+
   return (
     <section className="relative overflow-hidden bg-gradient-to-br from-background via-muted/20 to-background">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-20 pb-16 sm:pt-24 sm:pb-20 lg:pt-32 lg:pb-28">
@@ -136,6 +158,38 @@ export default function Hero({ cta }: { cta?: ReactNode }) {
                         <div className="text-xs text-secondary flex items-center mt-1">
                           <TrendingUp className="w-3 h-3 mr-1" />
                           Prédiction IA
+                        </div>
+                      </div>
+                      <div className="bg-card p-4 rounded-lg border border-primary/10 shadow-sm col-span-3">
+                        <ChartContainer
+                          config={{
+                            visitors: {
+                              label: "Visitors",
+                              color: "hsl(var(--chart-1))",
+                            },
+                          }}
+                        >
+                          <LineChart data={chartData}>
+                            <CartesianGrid strokeDasharray="3 3" />
+                            <XAxis dataKey="month" />
+                            <YAxis domain={[0, 10000]} />
+                            <ChartTooltip content={<ChartTooltipContent />} />
+                            <Line
+                              type="monotone"
+                              dataKey="visitors"
+                              stroke="var(--color-visitors)"
+                              strokeWidth={2}
+                              dot={false}
+                            />
+                          </LineChart>
+                        </ChartContainer>
+                      </div>
+                      <div className="bg-card p-4 rounded-lg border border-primary/10 shadow-sm">
+                        <div className="text-2xl font-bold text-primary">
+                          More data coming soon
+                        </div>
+                        <div className="text-sm text-muted-foreground">
+                          Stay tuned for additional insights
                         </div>
                       </div>
                     </div>


### PR DESCRIPTION
## Summary
- show traffic trends in hero with a full-width line chart for the previous six months
- add placeholder card for future data
- remove unused imports and state from demo page to satisfy lint

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689095662b448325aa5373f314de130c